### PR TITLE
feat(octocode-cli): add code-mode exec command

### DIFF
--- a/docs/specs/2026-04-16-octocode-agent-cli-design.md
+++ b/docs/specs/2026-04-16-octocode-agent-cli-design.md
@@ -1,0 +1,228 @@
+# Octocode Agent CLI Architecture
+
+Date: 2026-04-16 (revised 2026-04-17)
+Repo: `vltansky/octocode-mcp`
+Scope: Ship an agent-facing surface on the existing `octocode-cli` binary so coding agents get non-interactive parity with Octocode MCP for remote/provider-backed tools. Excludes local filesystem and LSP tools in v1.
+
+## Decision Summary
+
+Ship **per-tool subcommands** on the existing `octocode-cli` binary — one subcommand per tool with flag-style inputs — modeled on `sawyerhood/dev-browser`.
+
+Specifically:
+
+1. Add 6 per-tool subcommands that mirror the Octocode remote tools 1:1. Each takes the tool's required inputs as named flags and optional inputs as additional flags. All commands support `--json` for machine output.
+2. Every subcommand supports bulk mode via stdin: `echo '{"queries":[...]}' | octocode-cli <subcommand>` — the single JSON object path is a thin wrapper around the same executor used by the MCP server.
+3. Move the current interactive installer menu behind an explicit `octocode-cli install` (alias: `setup`).
+4. `octocode-cli` with no args prints top-level help (dev-browser style). No hidden default behavior.
+5. Keep the hidden `--tool <name>` entrypoint for two releases with a stderr deprecation notice.
+6. Defer consolidation work (package split, provider extraction, OAuth dedup, `executeTool` seam) until after v1 ships and real agent usage is measurable.
+
+**Why not generic `list | info | grep | call` verbs (mcp-s-style):** `@mcp-s/cli` exists to discover and drive *hundreds* of unknown tools exposed by third-party MCP servers. Octocode has 6 first-party remote tools we own and ship. A discovery/dispatch layer adds round-trips (`list → info → call`) and schema-shaped JSON payloads for no gain. Per-tool subcommands give agents direct `--help` pages and shell-native flag syntax — same model as `gh`, `kubectl`, `dev-browser`. Skills wrap the CLI with one-page cheat sheets, so discovery is solved at the skill layer, not at runtime.
+
+This supersedes the earlier Approach B / mcp-s-style draft.
+
+## Current State (verified)
+
+The repo is closer to the target than it looks:
+
+- **Execution is already decoupled from MCP transport.** Every tool splits `<tool>/execution.ts` (pure logic) from `<tool>/<tool>.ts` (register wrapper). E.g. `packages/octocode-mcp/src/tools/github_search_code/execution.ts` vs `github_search_code.ts:8-15`.
+- **Direct executors are already exported.** `packages/octocode-mcp/src/public/tools.ts:109-176` exports 13+ execution functions. v1 uses: `searchMultipleGitHubCode`, `fetchMultipleGitHubFileContents`, `exploreMultipleRepositoryStructures`, `searchMultipleGitHubRepos`, `searchMultipleGitHubPullRequests`, `searchPackages`.
+- **The canonical catalog already lives outside the repo.** `@octocodeai/octocode-core` (external npm dep, `^1.0.2`) publishes `OCTOCODE_TOOL_CATALOG`, `OCTOCODE_TOOL_NAMES`, `OctocodeToolCatalogEntry`, and Zod query schemas. v1 does not depend on the catalog at runtime — the CLI imports schemas directly from `octocode-mcp/public` as it already does.
+- **The CLI tool runner already exists.** `packages/octocode-cli/src/cli/tool-command.ts` (819 LOC) runs a hidden `--tool <name>` entrypoint with autofill (`id`, `mainResearchGoal`, `researchGoal`, `reasoning`) and the full validation + result envelope handling. The 6 new subcommands reuse this code path — they are thin flag-to-JSON wrappers.
+- **Auth is already transport-neutral.** `packages/octocode-shared/src/credentials/*` owns token resolution. CLI has a parallel device-flow OAuth (`features/github-oauth.ts`, 402 LOC). Left intact in v1.
+
+### What v1 does not touch
+
+- Provider extraction (`src/providers/{github,gitlab,bitbucket}/` stays in `octocode-mcp`).
+- Package rename or split (`octocode-cli` stays one package).
+- Auth consolidation (CLI OAuth stays as-is).
+- Cross-repo changes to `@octocodeai/octocode-core`.
+- Dynamic discovery/dispatch (`list | info | grep | call`).
+
+## Product Recommendation
+
+### Agent surface (6 per-tool subcommands)
+
+```bash
+# GitHub code search — required: --query
+octocode-cli search-code --query "useReducer dispatch" --owner facebook --repo react --language js --limit 10
+
+# File content — required: --owner --repo --path
+octocode-cli get-file --owner facebook --repo react \
+  --path packages/react-reconciler/src/ReactFiberHooks.js \
+  --match-string "dispatchReducerAction" --match-context-lines 3
+
+# Repo structure — required: --owner --repo
+octocode-cli view-structure --owner facebook --repo react --path packages --depth 2
+
+# Repo search — required: --query
+octocode-cli search-repos --query "react hooks" --limit 5
+
+# PR search — required: --owner --repo (or --query)
+octocode-cli search-prs --owner facebook --repo react --state closed --limit 10
+
+# Package search — required: --name --ecosystem
+octocode-cli package-search --name lodash --ecosystem npm
+```
+
+### Bulk mode (stdin)
+
+Agents that want to batch identical-shape queries pipe a `{queries:[...]}` payload:
+
+```bash
+echo '{"queries":[
+  {"keywordsToSearch":["useReducer"],"owner":"facebook","repo":"react"},
+  {"keywordsToSearch":["useState"],"owner":"facebook","repo":"react"}
+]}' | octocode-cli search-code
+```
+
+When stdin is piped AND flags are present, flags are ignored in favor of the stdin payload (with a stderr warning). When stdin is empty, flags build a single-query payload.
+
+### Administrative commands (unchanged or relocated)
+
+```bash
+octocode-cli install                    # interactive installer (was: no-args default)
+octocode-cli setup                      # alias for install
+octocode-cli login | logout | status    # unchanged auth verbs
+octocode-cli token                      # unchanged
+octocode-cli --version | --help         # unchanged
+```
+
+### Default behavior (no args)
+
+`octocode-cli` with no args prints top-level help. To open the installer menu explicitly: `octocode-cli install`.
+
+### Output modes
+
+- stdout: tool result (text blocks if present, else structured JSON).
+- stderr: errors, deprecation notices, diagnostics.
+- `--json`: always print the raw result envelope.
+
+### Exit codes
+
+- `0` success
+- `1` tool returned `isError` OR execution failed
+- `2` usage / validation error (reserved; v1 may still return `1` for these — document as "non-zero on error")
+
+### Autofill
+
+Keep the existing autofill for `id`, `mainResearchGoal`, `researchGoal`, `reasoning` (as implemented in `tool-command.ts:266-299`). Subcommand handlers pass through to the same path.
+
+### Deprecation
+
+`octocode-cli --tool <name>` stays for two releases with a stderr notice: `warning: --tool is deprecated; use 'octocode-cli <subcommand>'`. Remove after the notice window.
+
+### Why flags, not JSON payloads on the command line
+
+Agents are LLMs. Quoting nested JSON in shell is a known failure mode ("smart" quotes, escaped braces). Named flags are copy-paste safe from `--help` output, survive round-trips through markdown, and map 1:1 to the tool's schema. When an agent genuinely needs bulk input, stdin avoids the quoting problem entirely.
+
+## v1 Capability Scope
+
+Expose (6 tools → 6 subcommands):
+
+- `githubSearchCode` → `search-code`
+- `githubGetFileContent` → `get-file`
+- `githubViewRepoStructure` → `view-structure`
+- `githubSearchRepositories` → `search-repos`
+- `githubSearchPullRequests` → `search-prs`
+- `packageSearch` → `package-search`
+
+GitLab and Bitbucket equivalents: decide at ship time. The providers are already wired behind the shared abstractions, but UX of overloading `--owner/--repo` across three hosts needs a separate pass.
+
+Do not expose: local tools, LSP tools, clone/checkout, interactive installer over subcommands.
+
+## Migration Plan
+
+### P1 — v1 ship (single package, single release)
+
+Scope:
+
+- Add 6 per-tool subcommands. Each is a thin wrapper that builds a query object from flags and delegates to the existing `executeToolCommand` path.
+- Add `setup` as an alias for `install`.
+- Flip default: no-args → top-level help (was: interactive installer). Installer reached via `install` / `setup` subcommands.
+- Keep `--tool <name>` working, add stderr deprecation warning.
+- Ensure `isError → exit 1` wiring is correct in `executeToolCommand` (currently: `return !result.isError; if (!success) process.exitCode = 1;` — verify this is hit by the new commands).
+- Vitest tests: for each new subcommand — happy path via flags, bulk via stdin, `--json`, exit codes, autofill on/off, deprecation notice on `--tool`.
+- Doc updates: `packages/octocode-cli/docs/CLI_REFERENCE.md`.
+- Ship `skills/octocode-cli-usage/SKILL.md` — one-page agent cheat sheet (dev-browser style) listing the 6 subcommands and their most common flags.
+
+Out of scope for v1:
+
+- Updates to the 3 external skills (`octocode-install`, `octocode-engineer`, `octocode-research`) — these still reference `--tool`, which keeps working for two releases. Update in a follow-up release.
+- Package rename or split.
+- OAuth consolidation.
+- Provider extraction.
+- `executeTool` abstraction.
+- Cross-repo changes to `@octocodeai/octocode-core`.
+
+### P2 (optional, post-v1) — adoption-driven consolidation
+
+Only with data from real agent usage. Candidates, ranked by value:
+
+1. **OAuth dedup.** Audit CLI device flow vs `octocode-shared/credentials`. Backfill missing flows into shared. Delete the CLI copy (~500 LOC).
+2. **Fast-startup bin.** If cold-start times hurt measured usage, add a second `bin` entry that imports only runtime + credentials (no installer/UI). One extra file in the same package.
+3. **External skill refresh.** Rewrite `octocode-engineer` / `octocode-research` skills to use the new subcommands.
+4. **Provider extraction.** Move `src/providers/*` and clients into a transport-neutral location. MCP becomes a thin adapter. Only do this if a second consumer (VSCode extension, another harness) needs it.
+5. **Catalog-sourced descriptions.** Read tool descriptions and schemas from `OCTOCODE_TOOL_CATALOG` rather than hardcoding in CLI. Only makes sense once the CLI is held to the same "canonical catalog" standard as MCP.
+
+Every P2 item is independently shippable.
+
+### P3 (optional) — quality infrastructure
+
+- Drift CI: assert `OCTOCODE_TOOL_CATALOG` names == CLI-registered subcommands == MCP-registered tools. One test, high leverage.
+- Shell completions.
+- Generated skill/context blocks from the catalog.
+
+## Testing Strategy
+
+v1 only:
+
+1. **Vitest subcommand tests** per tool — flags → query object, stdin → queries array, `--json`, exit codes, autofill.
+2. **Existing `tool-command.test.ts`** must continue to pass with the deprecation notice added.
+3. **Manual check**: `npx octocode-cli` prints help; `npx octocode-cli install` still opens installer unchanged.
+
+Post-v1 (P3):
+
+- Drift test between catalog / CLI / MCP registrations.
+
+## Risks
+
+- **Behavior change: no-args no longer opens the installer.** Users typing `npx octocode-cli` expecting the menu now see help. `npm` weekly downloads are near zero — behavior-change risk is cosmetic. Mitigation: help output prominently shows `octocode-cli install`.
+- **Flag coverage vs schema coverage.** Each tool schema has more fields than we want as flags. Rule: required fields are flags; top-10 most-used optional fields are flags; everything else is reachable via stdin `{queries:[...]}`. Document this in `--help`.
+- **Quoting / escaping on Windows cmd.exe.** `--query "text with spaces"` works in PowerShell / bash / zsh / fish. Document the stdin escape hatch for cmd.exe users.
+- **Schema drift.** If a tool's schema changes upstream, the subcommand's flag list can go stale. Mitigation (post-v1): drift CI (P3).
+- **External skill references.** 3 public skills reference `--tool`. These break *only* if `--tool` is removed. Deprecation window (two releases) gives agents time to migrate; skills update in P2.
+- **OAuth drift persists.** Not addressed in v1 — flagged for P2.
+
+## Boundaries
+
+- **Always:** one package, one binary, per-tool subcommands, `--help` as the agent contract.
+- **Always:** `octocode-cli install` / `setup` is an explicit verb; no-args prints help.
+- **Always:** required fields are named flags; bulk payloads via stdin.
+- **Never:** require agents to construct JSON payloads on the command line as a positional arg.
+- **Never:** couple subcommand handlers to installer/UI/marketplace imports.
+- **Never:** invent new abstractions (`ToolSpec`, `executeTool`, dispatcher) before measuring a second consumer.
+- **Ask first:** whether v1 should include GitLab/Bitbucket or ship GitHub+package only and follow up.
+
+## Recommendation
+
+Ship P1 as one release:
+
+- 6 per-tool subcommands (`search-code | get-file | view-structure | search-repos | search-prs | package-search`), flag-driven with stdin bulk fallback.
+- Flip no-args from installer menu to help. Installer behind `install` / `setup`.
+- `--tool` still works, now with stderr deprecation notice.
+- Minimal one-page skill (`skills/octocode-cli-usage/SKILL.md`) in dev-browser style.
+
+Revisit consolidation (P2) only with data from real agent usage.
+
+## Grill Record
+
+This spec was stress-tested with `/vs-grill-me` on 2026-04-16 / 2026-04-17. Original output: READY_WITH_RISKS, 79/100, recommending mcp-s-style flat verbs (`list | info | grep | call`) on the existing binary.
+
+**Revision (2026-04-17):** The mcp-s pattern was rejected on a second pass as over-engineered for Octocode's small fixed tool set. mcp-s solves "drive hundreds of unknown tools"; Octocode ships 6 known tools we own. Replaced with per-tool subcommands modeled on `sawyerhood/dev-browser`. Discovery moves from runtime (`list`/`info` commands) to install-time (one-page skill). Key tradeoffs:
+
+- Schema drift risk: slightly higher (flags hand-mapped from schemas) vs mcp-s `info` being catalog-sourced. Mitigated via Vitest tests per subcommand + P3 drift CI.
+- Agent UX: strictly better — no round-trips, no JSON-quoting on the command line, `--help` is the contract.
+- Implementation cost: lower — thin wrappers over the existing `executeToolCommand` path.
+
+Falsifiability for P2: revisit consolidation (OAuth dedup, provider extraction) only if distinct agent sessions per week cross a threshold worth defining at ship time, OR a specific issue pattern emerges from real usage.

--- a/packages/octocode-cli/docs/CLI_REFERENCE.md
+++ b/packages/octocode-cli/docs/CLI_REFERENCE.md
@@ -83,6 +83,7 @@ Flag-driven, agent-friendly entry points. Each maps to one Octocode MCP tool and
 | `search-repos` | `githubSearchRepositories` | Search repositories by keywords/topics |
 | `search-prs` | `githubSearchPullRequests` | Search pull requests |
 | `package-search` | `packageSearch` | Search npm or Python packages |
+| `exec` | *code mode* | Run a JS script against the `oct.*` tool namespace |
 
 Examples:
 
@@ -103,6 +104,68 @@ echo '{"queries":[{"keywordsToSearch":["tool"],"owner":"bgauryy","repo":"octocod
 ```
 
 Add `--json` to any agent subcommand to print the raw tool envelope (useful for piping).
+
+### Exec (Code Mode)
+
+Run a JavaScript script that orchestrates multiple Octocode tools through a typed `oct.*` namespace. Useful when a task needs loops, batching with `Promise.all`, filtering, or multi-step research that would otherwise require several CLI calls.
+
+```bash
+octocode-cli exec '<script>' [--timeout <ms>] [--json]
+octocode-cli exec --file ./research.js
+echo 'return await oct.tools()' | octocode-cli exec
+```
+
+| Option | Meaning |
+|---|---|
+| `--file <path>` | Read the script from a file instead of a positional arg |
+| `--timeout <ms>` | Max execution time. Default: `60000` |
+| `--json` | Emit `{ returnValue, logs }` JSON instead of plain text |
+
+Script contract:
+
+- The script body runs inside an async IIFE — `await` and `return` work at the top level.
+- The `oct` namespace is the only bridge to Octocode tools. Input can be a single query object, an array of queries, or `{ queries: [...] }`. Shared research fields (`id`, `mainResearchGoal`, `researchGoal`, `reasoning`) are auto-filled.
+- `console.log` output is captured and printed before the return value.
+- The sandbox has no access to `require`, `import`, `process`, `fs`, or the network. Use `oct.*` exclusively.
+- Script errors (syntax, runtime, timeout, tool validation) set exit code `1`.
+
+`oct.*` surface:
+
+| Function | Tool |
+|---|---|
+| `oct.searchCode(q)` | `githubSearchCode` |
+| `oct.getFile(q)` | `githubGetFileContent` |
+| `oct.viewStructure(q)` | `githubViewRepoStructure` |
+| `oct.searchRepos(q)` | `githubSearchRepositories` |
+| `oct.searchPullRequests(q)` | `githubSearchPullRequests` |
+| `oct.packageSearch(q)` | `packageSearch` |
+| `oct.localSearchCode(q)` | `localSearchCode` |
+| `oct.localGetFile(q)` | `localGetFileContent` |
+| `oct.localFindFiles(q)` | `localFindFiles` |
+| `oct.localViewStructure(q)` | `localViewStructure` |
+| `oct.lspGotoDefinition(q)` | `lspGotoDefinition` |
+| `oct.lspFindReferences(q)` | `lspFindReferences` |
+| `oct.lspCallHierarchy(q)` | `lspCallHierarchy` |
+| `oct.tool(name, q)` | Invoke any tool by its canonical name |
+| `oct.tools()` | List all tool names |
+
+Example — fan out across several repos in parallel, filter, and summarize:
+
+```bash
+octocode-cli exec '
+  const repos = ["facebook/react", "vuejs/core", "sveltejs/svelte"];
+  const results = await Promise.all(
+    repos.map(slug => {
+      const [owner, repo] = slug.split("/");
+      return oct.searchCode({ owner, repo, keywordsToSearch: ["useState"] });
+    })
+  );
+  return results.map((r, i) => ({
+    repo: repos[i],
+    hits: r.structuredContent ?? r.content?.[0]?.text?.length ?? 0,
+  }));
+'
+```
 
 ## Install And Setup
 

--- a/packages/octocode-cli/docs/CLI_REFERENCE.md
+++ b/packages/octocode-cli/docs/CLI_REFERENCE.md
@@ -60,7 +60,7 @@ Tool behavior:
 
 | Command | Alias | Use it for |
 |---|---|---|
-| `install` | `i` | Configure `octocode-mcp` for a client |
+| `install` | `i`, `setup` | Configure `octocode-mcp` for a client |
 | `auth` | `a`, `gh` | Open auth menu or run auth subcommands |
 | `login` | `l` | Start GitHub OAuth login |
 | `logout` | - | Remove Octocode auth |
@@ -70,6 +70,39 @@ Tool behavior:
 | `mcp` | - | Manage marketplace MCPs non-interactively |
 | `skills` | `sk` | List, install, or remove bundled skills |
 | `cache` | - | Inspect or clean Octocode cache/logs |
+
+### Agent Subcommands
+
+Flag-driven, agent-friendly entry points. Each maps to one Octocode MCP tool and auto-fills `id`, `mainResearchGoal`, `researchGoal`, and `reasoning`.
+
+| Command | Tool | Use it for |
+|---|---|---|
+| `search-code` | `githubSearchCode` | Search code across GitHub repositories |
+| `get-file` | `githubGetFileContent` | Fetch a file (or a window around a match) |
+| `view-structure` | `githubViewRepoStructure` | List a repo directory tree |
+| `search-repos` | `githubSearchRepositories` | Search repositories by keywords/topics |
+| `search-prs` | `githubSearchPullRequests` | Search pull requests |
+| `package-search` | `packageSearch` | Search npm or Python packages |
+
+Examples:
+
+```bash
+octocode-cli search-code --query 'useReducer dispatch' --owner facebook --repo react
+octocode-cli get-file --owner facebook --repo react --path packages/react/src/React.js --match-string useState
+octocode-cli view-structure --owner bgauryy --repo octocode-mcp --depth 2
+octocode-cli search-repos --topics typescript,mcp --stars '>=100'
+octocode-cli search-prs --owner facebook --repo react --merged --limit 20
+octocode-cli package-search --name react --ecosystem npm
+```
+
+Bulk queries: pipe `{"queries":[...]}` JSON on stdin to any subcommand. Flags are ignored when stdin is supplied.
+
+```bash
+echo '{"queries":[{"keywordsToSearch":["tool"],"owner":"bgauryy","repo":"octocode-mcp"}]}' \
+  | octocode-cli search-code
+```
+
+Add `--json` to any agent subcommand to print the raw tool envelope (useful for piping).
 
 ## Install And Setup
 

--- a/packages/octocode-cli/src/cli/agent-commands.ts
+++ b/packages/octocode-cli/src/cli/agent-commands.ts
@@ -1,0 +1,404 @@
+import type { CLICommand, ParsedArgs } from './types.js';
+import { executeToolCommand } from './tool-command.js';
+import { c, dim } from '../utils/colors.js';
+
+type FlagType = 'string' | 'number' | 'boolean' | 'array';
+
+interface FlagDef {
+  name: string;
+  short?: string;
+  description: string;
+  required?: boolean;
+  type?: FlagType;
+  field?: string;
+  default?: string | number | boolean;
+}
+
+interface AgentCommandSpec {
+  name: string;
+  tool: string;
+  description: string;
+  usage: string;
+  flags: FlagDef[];
+}
+
+const AGENT_COMMAND_SPECS: AgentCommandSpec[] = [
+  {
+    name: 'search-code',
+    tool: 'githubSearchCode',
+    description: 'Search code in GitHub repositories',
+    usage:
+      "octocode search-code --query '<terms>' [--owner <org>] [--repo <name>] [--path <path>] [--extension <ext>] [--limit <n>] [--json]",
+    flags: [
+      {
+        name: 'query',
+        description:
+          'Search terms (comma-separated for multiple). Maps to keywordsToSearch.',
+        required: true,
+        type: 'array',
+        field: 'keywordsToSearch',
+      },
+      { name: 'owner', description: 'Repository owner' },
+      { name: 'repo', description: 'Repository name' },
+      { name: 'path', description: 'Path filter (directory prefix)' },
+      { name: 'filename', description: 'Filename filter' },
+      { name: 'extension', description: 'File extension (without dot)' },
+      { name: 'match', description: 'Match on: path | file' },
+      { name: 'limit', description: 'Max results', type: 'number' },
+      { name: 'page', description: 'Page number', type: 'number' },
+    ],
+  },
+  {
+    name: 'get-file',
+    tool: 'githubGetFileContent',
+    description: 'Fetch file content from a GitHub repository',
+    usage:
+      'octocode get-file --owner <org> --repo <name> --path <path> [--match-string <text>] [--start-line <n>] [--end-line <n>] [--full-content] [--json]',
+    flags: [
+      { name: 'owner', description: 'Repository owner', required: true },
+      { name: 'repo', description: 'Repository name', required: true },
+      { name: 'path', description: 'File path in repo', required: true },
+      { name: 'branch', description: 'Branch or ref (default: main)' },
+      { name: 'type', description: 'Entry type: file | directory' },
+      {
+        name: 'match-string',
+        description: 'Return only lines around this match',
+      },
+      {
+        name: 'match-context-lines',
+        description: 'Context lines around matchString',
+        type: 'number',
+      },
+      {
+        name: 'start-line',
+        description: 'Start line (1-based)',
+        type: 'number',
+      },
+      { name: 'end-line', description: 'End line (inclusive)', type: 'number' },
+      {
+        name: 'full-content',
+        description: 'Return full file (ignores start/end/match)',
+        type: 'boolean',
+      },
+    ],
+  },
+  {
+    name: 'view-structure',
+    tool: 'githubViewRepoStructure',
+    description: 'View directory structure of a GitHub repository',
+    usage:
+      'octocode view-structure --owner <org> --repo <name> [--path <path>] [--depth <n>] [--branch <ref>] [--json]',
+    flags: [
+      { name: 'owner', description: 'Repository owner', required: true },
+      { name: 'repo', description: 'Repository name', required: true },
+      { name: 'branch', description: 'Branch or ref' },
+      { name: 'path', description: 'Starting path (default: repo root)' },
+      { name: 'depth', description: 'Tree depth', type: 'number' },
+      {
+        name: 'entries-per-page',
+        description: 'Entries per page',
+        type: 'number',
+      },
+      {
+        name: 'entry-page-number',
+        description: 'Page number (1-based)',
+        type: 'number',
+      },
+    ],
+  },
+  {
+    name: 'search-repos',
+    tool: 'githubSearchRepositories',
+    description: 'Search GitHub repositories',
+    usage:
+      "octocode search-repos --query '<terms>' [--owner <org>] [--limit <n>] [--sort <stars|updated|forks|best-match>] [--json]",
+    flags: [
+      {
+        name: 'query',
+        description:
+          'Search terms (comma-separated). Maps to keywordsToSearch.',
+        type: 'array',
+        field: 'keywordsToSearch',
+      },
+      {
+        name: 'topics',
+        description: 'Topic list (comma-separated). Maps to topicsToSearch.',
+        type: 'array',
+        field: 'topicsToSearch',
+      },
+      { name: 'owner', description: 'Filter by owner' },
+      { name: 'stars', description: 'Star range, e.g. ">=100" or "10..500"' },
+      { name: 'size', description: 'Size range in KB' },
+      { name: 'created', description: 'Created-at date range' },
+      { name: 'updated', description: 'Updated-at date range' },
+      {
+        name: 'sort',
+        description: 'Sort by: stars | updated | forks | best-match',
+      },
+      { name: 'limit', description: 'Max results', type: 'number' },
+      { name: 'page', description: 'Page number', type: 'number' },
+    ],
+  },
+  {
+    name: 'search-prs',
+    tool: 'githubSearchPullRequests',
+    description: 'Search GitHub pull requests',
+    usage:
+      "octocode search-prs [--owner <org>] [--repo <name>] [--query '<text>'] [--state <open|closed>] [--author <user>] [--limit <n>] [--json]",
+    flags: [
+      { name: 'query', description: 'Free-text search' },
+      { name: 'owner', description: 'Repository owner' },
+      { name: 'repo', description: 'Repository name' },
+      { name: 'pr-number', description: 'Specific PR number', type: 'number' },
+      { name: 'state', description: 'Filter by state: open | closed' },
+      { name: 'author', description: 'Author username' },
+      { name: 'assignee', description: 'Assignee username' },
+      { name: 'commenter', description: 'Commenter username' },
+      { name: 'involves', description: 'User involved (any role)' },
+      { name: 'mentions', description: 'User mentioned' },
+      { name: 'head', description: 'Head branch name' },
+      { name: 'base', description: 'Base branch name' },
+      { name: 'created', description: 'Created-at date range' },
+      { name: 'updated', description: 'Updated-at date range' },
+      { name: 'closed', description: 'Closed-at date range' },
+      { name: 'merged', description: 'Merged PRs only', type: 'boolean' },
+      { name: 'draft', description: 'Draft PRs only', type: 'boolean' },
+      {
+        name: 'sort',
+        description: 'Sort by: created | updated | best-match',
+      },
+      { name: 'order', description: 'Sort order: asc | desc' },
+      { name: 'limit', description: 'Max results', type: 'number' },
+      { name: 'page', description: 'Page number', type: 'number' },
+      {
+        name: 'with-comments',
+        description: 'Include comments',
+        type: 'boolean',
+      },
+      {
+        name: 'with-commits',
+        description: 'Include commits',
+        type: 'boolean',
+      },
+      {
+        name: 'type',
+        description: 'Detail level: fullContent | metadata | partialContent',
+      },
+    ],
+  },
+  {
+    name: 'package-search',
+    tool: 'packageSearch',
+    description: 'Search npm or Python packages',
+    usage:
+      'octocode package-search --name <package> --ecosystem <npm|python> [--search-limit <n>] [--json]',
+    flags: [
+      { name: 'name', description: 'Package name', required: true },
+      {
+        name: 'ecosystem',
+        description: 'Ecosystem: npm | python',
+        required: true,
+      },
+      {
+        name: 'search-limit',
+        description: 'Max matches',
+        type: 'number',
+      },
+      {
+        name: 'npm-fetch-metadata',
+        description: 'Fetch npm metadata (npm only)',
+        type: 'boolean',
+      },
+      {
+        name: 'python-fetch-metadata',
+        description: 'Fetch PyPI metadata (python only)',
+        type: 'boolean',
+      },
+    ],
+  },
+];
+
+function kebabToCamel(name: string): string {
+  return name.replace(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
+}
+
+function buildQueryFromFlags(
+  spec: AgentCommandSpec,
+  options: Record<string, string | boolean>
+): Record<string, unknown> {
+  const query: Record<string, unknown> = {};
+
+  for (const flag of spec.flags) {
+    const value = options[flag.name];
+    if (value === undefined) continue;
+
+    const field = flag.field ?? kebabToCamel(flag.name);
+    const type = flag.type ?? 'string';
+
+    if (type === 'boolean') {
+      query[field] = Boolean(value);
+      continue;
+    }
+
+    if (typeof value !== 'string') {
+      if (type === 'array' && value === true) {
+        continue;
+      }
+      query[field] = value;
+      continue;
+    }
+
+    if (type === 'number') {
+      const n = Number(value);
+      if (Number.isFinite(n)) {
+        query[field] = n;
+      } else {
+        throw new Error(`--${flag.name} must be a number, got "${value}"`);
+      }
+      continue;
+    }
+
+    if (type === 'array') {
+      query[field] = value
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+      continue;
+    }
+
+    query[field] = value;
+  }
+
+  return query;
+}
+
+function validateRequiredFlags(
+  spec: AgentCommandSpec,
+  options: Record<string, string | boolean>
+): string[] {
+  const missing: string[] = [];
+  for (const flag of spec.flags) {
+    if (flag.required && options[flag.name] === undefined) {
+      missing.push(`--${flag.name}`);
+    }
+  }
+  return missing;
+}
+
+function printAgentError(message: string, details: string[] = []): void {
+  console.error();
+  console.error(`  ${c('red', 'X')} ${message}`);
+  for (const detail of details) {
+    console.error(`  ${dim('-')} ${detail}`);
+  }
+  console.error();
+}
+
+async function readStdinJson(): Promise<string | null> {
+  if (process.stdin.isTTY) return null;
+
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => {
+      const trimmed = data.trim();
+      resolve(trimmed.length > 0 ? trimmed : null);
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+function hasAnyFlag(
+  spec: AgentCommandSpec,
+  options: Record<string, string | boolean>
+): boolean {
+  return spec.flags.some(flag => options[flag.name] !== undefined);
+}
+
+async function runAgentSubcommand(
+  spec: AgentCommandSpec,
+  args: ParsedArgs
+): Promise<void> {
+  const stdinPayload = await readStdinJson();
+
+  let payloadJson: string;
+
+  if (stdinPayload !== null) {
+    if (hasAnyFlag(spec, args.options)) {
+      console.error(
+        `  ${dim('note: stdin payload detected; ignoring command-line flags')}`
+      );
+    }
+    payloadJson = stdinPayload;
+  } else {
+    const missing = validateRequiredFlags(spec, args.options);
+    if (missing.length > 0) {
+      printAgentError(
+        `Missing required flag${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`,
+        [
+          `Usage: ${spec.usage.replace(/\boctocode\b/g, 'octocode-cli')}`,
+          `Run 'octocode-cli ${spec.name} --help' for details.`,
+        ]
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    let query: Record<string, unknown>;
+    try {
+      query = buildQueryFromFlags(spec, args.options);
+    } catch (err) {
+      printAgentError(
+        err instanceof Error ? err.message : 'Invalid flag value'
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    payloadJson = JSON.stringify(query);
+  }
+
+  const toolArgs: ParsedArgs = {
+    command: 'tool',
+    args: [spec.tool, payloadJson],
+    options: {
+      tool: spec.tool,
+      ...(args.options.json === true ? { json: true } : {}),
+      ...(typeof args.options.output === 'string'
+        ? { output: args.options.output }
+        : {}),
+    },
+  };
+
+  const success = await executeToolCommand(toolArgs);
+  if (!success) {
+    process.exitCode = 1;
+  }
+}
+
+function toCLICommand(spec: AgentCommandSpec): CLICommand {
+  return {
+    name: spec.name,
+    description: spec.description,
+    usage: spec.usage,
+    options: [
+      ...spec.flags.map(flag => ({
+        name: flag.name,
+        short: flag.short,
+        description: flag.description + (flag.required ? ' [required]' : ''),
+        hasValue: flag.type !== 'boolean',
+      })),
+      {
+        name: 'json',
+        description: 'Print raw JSON result envelope to stdout',
+      },
+    ],
+    handler: (args: ParsedArgs) => runAgentSubcommand(spec, args),
+  };
+}
+
+export const agentCommands: CLICommand[] =
+  AGENT_COMMAND_SPECS.map(toCLICommand);

--- a/packages/octocode-cli/src/cli/commands.ts
+++ b/packages/octocode-cli/src/cli/commands.ts
@@ -26,6 +26,7 @@ import { IDE_INFO, CLIENT_INFO, INSTALL_METHOD_INFO } from '../ui/constants.js';
 import { Spinner } from '../utils/spinner.js';
 import { toolCommand } from './tool-command.js';
 import { agentCommands } from './agent-commands.js';
+import { execCommand } from './exec-command.js';
 import { runInteractiveMode } from '../interactive.js';
 
 function getIDEDisplayName(ide: string): string {
@@ -1987,6 +1988,7 @@ const commands: CLICommand[] = [
   tokenCommand,
   statusCommand,
   syncCommand,
+  execCommand,
   ...agentCommands,
 ];
 

--- a/packages/octocode-cli/src/cli/commands.ts
+++ b/packages/octocode-cli/src/cli/commands.ts
@@ -6,11 +6,7 @@ import type {
   MCPServer,
 } from '../types/index.js';
 import { c, bold, dim } from '../utils/colors.js';
-import {
-  installOctocode,
-  detectAvailableIDEs,
-  getInstallPreview,
-} from '../features/install.js';
+import { installOctocode, getInstallPreview } from '../features/install.js';
 import {
   login as oauthLogin,
   logout as oauthLogout,
@@ -29,6 +25,8 @@ import { checkNodeInPath, checkNpmInPath } from '../features/node-check.js';
 import { IDE_INFO, CLIENT_INFO, INSTALL_METHOD_INFO } from '../ui/constants.js';
 import { Spinner } from '../utils/spinner.js';
 import { toolCommand } from './tool-command.js';
+import { agentCommands } from './agent-commands.js';
+import { runInteractiveMode } from '../interactive.js';
 
 function getIDEDisplayName(ide: string): string {
   if (ide in CLIENT_INFO) {
@@ -374,7 +372,7 @@ function formatTokenSource(source: TokenSource, envSource?: string): string {
 
 const installCommand: CLICommand = {
   name: 'install',
-  aliases: ['i'],
+  aliases: ['i', 'setup'],
   description: 'Install octocode-mcp for an IDE',
   usage: 'octocode install --ide <ide> [--method <npx|direct>] [--force]',
   options: [
@@ -401,6 +399,11 @@ const installCommand: CLICommand = {
     const ide = args.options['ide'] as IDE | undefined;
     const method = (args.options['method'] || 'npx') as InstallMethod;
     const force = Boolean(args.options['force'] || args.options['f']);
+
+    if (!ide) {
+      await runInteractiveMode();
+      return;
+    }
 
     if (method === 'npx') {
       const nodeCheck = checkNodeInPath();
@@ -431,32 +434,6 @@ const installCommand: CLICommand = {
         process.exitCode = 1;
         return;
       }
-    }
-
-    if (!ide) {
-      const available = detectAvailableIDEs();
-      console.log();
-      console.log(
-        `  ${c('red', '✗')} Missing required option: ${c('cyan', '--ide')}`
-      );
-      console.log();
-
-      if (available.length > 0) {
-        console.log(`  ${bold('Available IDEs:')}`);
-        for (const availableIde of available) {
-          console.log(`    ${c('cyan', '•')} ${availableIde}`);
-        }
-      } else {
-        console.log(`  ${c('yellow', '⚠')} No supported IDEs detected.`);
-        console.log(`  ${dim('Install Cursor or Claude Desktop first.')}`);
-      }
-      console.log();
-      console.log(
-        `  ${dim('Usage:')} octocode install --ide cursor --method npx`
-      );
-      console.log();
-      process.exitCode = 1;
-      return;
     }
 
     const supportedIDEs = [
@@ -2010,6 +1987,7 @@ const commands: CLICommand[] = [
   tokenCommand,
   statusCommand,
   syncCommand,
+  ...agentCommands,
 ];
 
 export function findCommand(name: string): CLICommand | undefined {

--- a/packages/octocode-cli/src/cli/exec-command.ts
+++ b/packages/octocode-cli/src/cli/exec-command.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from 'node:fs';
+import type { CLICommand, ParsedArgs } from './types.js';
+import { c, dim } from '../utils/colors.js';
+import { runOctocodeScript } from './exec-runtime.js';
+
+function printExecError(message: string, details: string[] = []): void {
+  console.error();
+  console.error(`  ${c('red', 'X')} ${message}`);
+  for (const detail of details) {
+    console.error(`  ${dim('-')} ${detail}`);
+  }
+  console.error();
+}
+
+async function readStdin(): Promise<string | null> {
+  if (process.stdin.isTTY) return null;
+
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => {
+      resolve(data.length > 0 ? data : null);
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readScriptSource(args: ParsedArgs): Promise<string | null> {
+  const fileOpt = args.options['file'];
+  if (typeof fileOpt === 'string' && fileOpt.length > 0) {
+    try {
+      return readFileSync(fileOpt, 'utf8');
+    } catch (err) {
+      throw new Error(
+        `Cannot read script file "${fileOpt}": ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const firstArg = args.args[0];
+  if (typeof firstArg === 'string' && firstArg.length > 0) {
+    return firstArg;
+  }
+
+  return readStdin();
+}
+
+function parseTimeout(raw: unknown): number | undefined {
+  if (raw === undefined || raw === true) return undefined;
+  if (typeof raw !== 'string') return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`--timeout must be a positive number of ms, got "${raw}"`);
+  }
+  return n;
+}
+
+function formatReturnValue(value: unknown): string {
+  if (value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+async function runExecCommand(args: ParsedArgs): Promise<void> {
+  let scriptSource: string | null;
+  try {
+    scriptSource = await readScriptSource(args);
+  } catch (err) {
+    printExecError(
+      err instanceof Error ? err.message : 'Failed to read script'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!scriptSource || scriptSource.trim().length === 0) {
+    printExecError('No script provided.', [
+      "Pass a script inline: octocode-cli exec 'console.log(await oct.tools())'",
+      'Or via file: octocode-cli exec --file ./script.js',
+      "Or via stdin: echo 'return await oct.tools()' | octocode-cli exec",
+    ]);
+    process.exitCode = 1;
+    return;
+  }
+
+  let timeoutMs: number | undefined;
+  try {
+    timeoutMs = parseTimeout(args.options['timeout']);
+  } catch (err) {
+    printExecError(err instanceof Error ? err.message : 'Invalid --timeout');
+    process.exitCode = 1;
+    return;
+  }
+
+  const jsonOutput = args.options.json === true;
+
+  try {
+    const { returnValue, logs } = await runOctocodeScript(scriptSource, {
+      timeoutMs,
+    });
+
+    if (jsonOutput) {
+      console.log(
+        JSON.stringify({ returnValue: returnValue ?? null, logs }, null, 2)
+      );
+      return;
+    }
+
+    for (const line of logs) {
+      console.log(line);
+    }
+
+    const formatted = formatReturnValue(returnValue);
+    if (formatted.length > 0) {
+      console.log(formatted);
+    }
+  } catch (err) {
+    printExecError(
+      err instanceof Error ? err.message : 'Script execution failed'
+    );
+    process.exitCode = 1;
+  }
+}
+
+export const execCommand: CLICommand = {
+  name: 'exec',
+  description:
+    'Run a JavaScript script against the Octocode tool namespace (oct.*)',
+  usage:
+    "octocode exec '<script>' | --file <path> | stdin  [--timeout <ms>] [--json]",
+  options: [
+    {
+      name: 'file',
+      description: 'Read script from file instead of positional arg',
+      hasValue: true,
+    },
+    {
+      name: 'timeout',
+      description: 'Script timeout in ms (default: 60000)',
+      hasValue: true,
+      default: '60000',
+    },
+    {
+      name: 'json',
+      description: 'Print { returnValue, logs } as JSON instead of plain text',
+    },
+  ],
+  handler: runExecCommand,
+};

--- a/packages/octocode-cli/src/cli/exec-runtime.ts
+++ b/packages/octocode-cli/src/cli/exec-runtime.ts
@@ -1,0 +1,280 @@
+import vm from 'node:vm';
+import { z } from 'zod/v4';
+import {
+  TOOL_DEFINITIONS,
+  applyDefaultQueryFields,
+  normalizeQueryObject,
+  ensureToolRuntimeReady,
+  type ToolDefinition,
+  type ToolResult,
+} from './tool-command.js';
+
+export type OctToolFn = (input?: unknown) => Promise<ToolResult>;
+
+export interface OctNamespace {
+  searchCode: OctToolFn;
+  getFile: OctToolFn;
+  viewStructure: OctToolFn;
+  searchRepos: OctToolFn;
+  searchPullRequests: OctToolFn;
+  packageSearch: OctToolFn;
+  localSearchCode: OctToolFn;
+  localGetFile: OctToolFn;
+  localFindFiles: OctToolFn;
+  localViewStructure: OctToolFn;
+  lspGotoDefinition: OctToolFn;
+  lspFindReferences: OctToolFn;
+  lspCallHierarchy: OctToolFn;
+  tool: (name: string, input?: unknown) => Promise<ToolResult>;
+  tools: () => string[];
+}
+
+const OCT_NAMESPACE_MAP: Record<string, string> = {
+  githubSearchCode: 'searchCode',
+  githubGetFileContent: 'getFile',
+  githubViewRepoStructure: 'viewStructure',
+  githubSearchRepositories: 'searchRepos',
+  githubSearchPullRequests: 'searchPullRequests',
+  packageSearch: 'packageSearch',
+  localSearchCode: 'localSearchCode',
+  localGetFileContent: 'localGetFile',
+  localFindFiles: 'localFindFiles',
+  localViewStructure: 'localViewStructure',
+  lspGotoDefinition: 'lspGotoDefinition',
+  lspFindReferences: 'lspFindReferences',
+  lspCallHierarchy: 'lspCallHierarchy',
+};
+
+function findDefinition(toolName: string): ToolDefinition {
+  const def = TOOL_DEFINITIONS.find(t => t.name === toolName);
+  if (!def) {
+    throw new Error(`Unknown Octocode tool: ${toolName}`);
+  }
+  return def;
+}
+
+interface NormalizedPayload {
+  queries: Array<Record<string, unknown>>;
+  responseCharLength?: number;
+  responseCharOffset?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeInput(toolName: string, input: unknown): NormalizedPayload {
+  let rawQueries: unknown[] = [];
+  let responseCharLength: number | undefined;
+  let responseCharOffset: number | undefined;
+
+  if (input === undefined) {
+    throw new Error(`oct.${toolName} requires an input object.`);
+  }
+
+  if (Array.isArray(input)) {
+    rawQueries = input;
+  } else if (isRecord(input) && Array.isArray(input.queries)) {
+    rawQueries = input.queries;
+    if (typeof input.responseCharLength === 'number') {
+      responseCharLength = input.responseCharLength;
+    }
+    if (typeof input.responseCharOffset === 'number') {
+      responseCharOffset = input.responseCharOffset;
+    }
+  } else if (isRecord(input)) {
+    rawQueries = [input];
+  } else {
+    throw new Error(
+      `oct.${toolName}: input must be an object, array of objects, or { queries: [...] }.`
+    );
+  }
+
+  if (rawQueries.length === 0) {
+    throw new Error(`oct.${toolName}: at least one query is required.`);
+  }
+
+  const queries = rawQueries.map((query, index) =>
+    applyDefaultQueryFields(toolName, index, normalizeQueryObject(query))
+  );
+
+  return { queries, responseCharLength, responseCharOffset };
+}
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'input';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+async function runTool(toolName: string, input: unknown): Promise<ToolResult> {
+  const def = findDefinition(toolName);
+  const payload = normalizeInput(toolName, input);
+
+  const parsed = payload.queries.map(q => def.schema.safeParse(q));
+  const failure = parsed.find(r => !r.success);
+  if (failure && !failure.success) {
+    throw new Error(
+      `oct.${toolName}: input validation failed — ${formatZodIssues(failure.error)}`
+    );
+  }
+
+  const validated = parsed
+    .filter(
+      (r): r is z.ZodSafeParseSuccess<Record<string, unknown>> => r.success
+    )
+    .map(r => r.data);
+
+  await ensureToolRuntimeReady();
+
+  return def.execute({
+    queries: validated,
+    responseCharLength: payload.responseCharLength,
+    responseCharOffset: payload.responseCharOffset,
+  });
+}
+
+export function createOctNamespace(): OctNamespace {
+  const ns: Record<string, unknown> = {
+    tool: (name: string, input?: unknown) => runTool(name, input),
+    tools: () => TOOL_DEFINITIONS.map(t => t.name),
+  };
+
+  for (const def of TOOL_DEFINITIONS) {
+    const alias = OCT_NAMESPACE_MAP[def.name];
+    if (!alias) continue;
+    ns[alias] = (input?: unknown) => runTool(def.name, input);
+  }
+
+  return ns as unknown as OctNamespace;
+}
+
+export interface RunScriptOptions {
+  timeoutMs?: number;
+  filename?: string;
+  onLog?: (line: string) => void;
+}
+
+export interface RunScriptResult {
+  returnValue: unknown;
+  logs: string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+function formatLogArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack ?? arg.message;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function buildSandboxedConsole(
+  logs: string[],
+  onLog?: (line: string) => void
+): Console {
+  const record =
+    (level: string) =>
+    (...args: unknown[]) => {
+      const line = args.map(formatLogArg).join(' ');
+      const tagged = level === 'log' ? line : `[${level}] ${line}`;
+      logs.push(tagged);
+      onLog?.(tagged);
+    };
+
+  return {
+    log: record('log'),
+    info: record('info'),
+    warn: record('warn'),
+    error: record('error'),
+    debug: record('debug'),
+    trace: record('trace'),
+  } as unknown as Console;
+}
+
+export async function runOctocodeScript(
+  code: string,
+  options: RunScriptOptions = {}
+): Promise<RunScriptResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const filename = options.filename ?? 'octocode-exec.js';
+  const logs: string[] = [];
+
+  const oct = createOctNamespace();
+  const sandboxConsole = buildSandboxedConsole(logs, options.onLog);
+
+  const context = vm.createContext({
+    oct,
+    console: sandboxConsole,
+    JSON,
+    Math,
+    Date,
+    Promise,
+    Array,
+    Object,
+    Map,
+    Set,
+    WeakMap,
+    WeakSet,
+    Symbol,
+    Number,
+    String,
+    Boolean,
+    RegExp,
+    Error,
+    TypeError,
+    RangeError,
+    URL,
+    URLSearchParams,
+    Buffer,
+    AbortController,
+    AbortSignal,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    queueMicrotask,
+    atob,
+    btoa,
+    encodeURIComponent,
+    decodeURIComponent,
+    encodeURI,
+    decodeURI,
+    parseInt,
+    parseFloat,
+    isNaN,
+    isFinite,
+  });
+
+  const wrapped = `(async () => {\n${code}\n})()`;
+
+  let script: vm.Script;
+  try {
+    script = new vm.Script(wrapped, { filename });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Syntax error in script: ${message}`);
+  }
+
+  const promise = script.runInContext(context) as Promise<unknown>;
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Script exceeded timeout of ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    const returnValue = await Promise.race([promise, timeoutPromise]);
+    return { returnValue, logs };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/octocode-cli/src/cli/help.ts
+++ b/packages/octocode-cli/src/cli/help.ts
@@ -12,32 +12,54 @@ export function showHelp(): void {
   console.log(`  ${bold('USAGE')}`);
   console.log(`    ${c('magenta', 'octocode-cli')} [command] [options]`);
   console.log();
-  console.log(`  ${bold('COMMANDS')}`);
+  console.log(`  ${bold('AGENT TOOLS')}`);
   console.log(
-    `    ${c('magenta', 'install')}     Configure octocode-mcp for an IDE`
+    `    ${c('magenta', 'search-code')}      Search code in GitHub repositories`
   );
   console.log(
-    `    ${c('magenta', 'skills')}      Install Octocode skills across AI clients`
+    `    ${c('magenta', 'get-file')}         Fetch file content from a GitHub repo`
   );
   console.log(
-    `    ${c('magenta', 'cache')}       Inspect and clean Octocode cache directories`
+    `    ${c('magenta', 'view-structure')}   View directory structure of a GitHub repo`
   );
   console.log(
-    `    ${c('magenta', 'sync')}        Sync MCP configurations across all IDEs`
+    `    ${c('magenta', 'search-repos')}     Search GitHub repositories`
   );
   console.log(
-    `    ${c('magenta', 'mcp')}         Manage MCP marketplace non-interactively`
+    `    ${c('magenta', 'search-prs')}       Search GitHub pull requests`
   );
   console.log(
-    `    ${c('magenta', 'auth')}        Manage GitHub authentication`
+    `    ${c('magenta', 'package-search')}   Search npm or Python packages`
   );
-  console.log(`    ${c('magenta', 'login')}       Authenticate with GitHub`);
-  console.log(`    ${c('magenta', 'logout')}      Sign out from GitHub`);
+  console.log();
+  console.log(`  ${bold('SETUP & ADMIN')}`);
   console.log(
-    `    ${c('magenta', 'status')}      Show GitHub authentication status`
+    `    ${c('magenta', 'install')}          Configure octocode-mcp (alias: setup)`
   );
   console.log(
-    `    ${c('magenta', 'token')}       Print the stored GitHub OAuth token`
+    `    ${c('magenta', 'skills')}           Install Octocode skills across AI clients`
+  );
+  console.log(
+    `    ${c('magenta', 'cache')}            Inspect and clean Octocode cache directories`
+  );
+  console.log(
+    `    ${c('magenta', 'sync')}             Sync MCP configurations across all IDEs`
+  );
+  console.log(
+    `    ${c('magenta', 'mcp')}              Manage MCP marketplace non-interactively`
+  );
+  console.log(
+    `    ${c('magenta', 'auth')}             Manage GitHub authentication`
+  );
+  console.log(
+    `    ${c('magenta', 'login')}            Authenticate with GitHub`
+  );
+  console.log(`    ${c('magenta', 'logout')}           Sign out from GitHub`);
+  console.log(
+    `    ${c('magenta', 'status')}           Show GitHub authentication status`
+  );
+  console.log(
+    `    ${c('magenta', 'token')}            Print the stored GitHub OAuth token`
   );
   console.log();
   console.log(`  ${bold('OPTIONS')}`);
@@ -51,10 +73,27 @@ export function showHelp(): void {
   console.log(`    ${c('cyan', '-v, --version')}    Show version number`);
   console.log();
   console.log(`  ${bold('EXAMPLES')}`);
-  console.log(`    ${dim('# Interactive mode')}`);
-  console.log(`    ${c('yellow', 'octocode-cli')}`);
+  console.log(`    ${dim('# Search code in a GitHub repo')}`);
+  console.log(
+    `    ${c('yellow', "octocode-cli search-code --query 'useReducer dispatch' --owner facebook --repo react")}`
+  );
   console.log();
-  console.log(`    ${dim('# Install for Cursor using npx')}`);
+  console.log(`    ${dim('# Fetch a file around a matched string')}`);
+  console.log(
+    `    ${c('yellow', 'octocode-cli get-file --owner facebook --repo react --path packages/react/src/React.js --match-string useState')}`
+  );
+  console.log();
+  console.log(`    ${dim('# Bulk search via stdin')}`);
+  console.log(
+    `    ${c('yellow', `echo '{"queries":[...]}' | octocode-cli search-code`)}`
+  );
+  console.log();
+  console.log(`    ${dim('# Interactive installer')}`);
+  console.log(
+    `    ${c('yellow', 'octocode-cli install')}    ${dim('(alias: setup)')}`
+  );
+  console.log();
+  console.log(`    ${dim('# Non-interactive install for Cursor')}`);
   console.log(
     `    ${c('yellow', 'octocode-cli install --ide cursor --method npx')}`
   );

--- a/packages/octocode-cli/src/cli/help.ts
+++ b/packages/octocode-cli/src/cli/help.ts
@@ -31,6 +31,9 @@ export function showHelp(): void {
   console.log(
     `    ${c('magenta', 'package-search')}   Search npm or Python packages`
   );
+  console.log(
+    `    ${c('magenta', 'exec')}             Run a JS script against the oct.* tool namespace`
+  );
   console.log();
   console.log(`  ${bold('SETUP & ADMIN')}`);
   console.log(
@@ -138,6 +141,12 @@ export function showHelp(): void {
   console.log(
     `    ${c('yellow', 'octocode-cli skills remove --skill octocode-researcher --targets claude-code,cursor')}`
   );
+  console.log();
+  console.log(`    ${dim('# Run a code-mode script (oct.* namespace)')}`);
+  console.log(
+    `    ${c('yellow', `octocode-cli exec 'const r = await oct.searchCode({owner:"facebook",repo:"react",keywordsToSearch:["useState"]}); console.log(r.content[0].text);'`)}`
+  );
+  console.log(`    ${c('yellow', 'octocode-cli exec --file ./research.js')}`);
   console.log();
   console.log(`    ${dim('# Run a tool directly')}`);
   console.log(

--- a/packages/octocode-cli/src/cli/index.ts
+++ b/packages/octocode-cli/src/cli/index.ts
@@ -69,6 +69,10 @@ export async function runCLI(argv?: string[]): Promise<boolean> {
       return true;
     }
 
+    console.error(
+      "  warning: --tool is deprecated; use 'octocode-cli <subcommand>' (e.g. search-code, get-file). See 'octocode-cli --help'."
+    );
+
     const success = await executeToolCommand(args);
     if (!success) {
       process.exitCode = 1;

--- a/packages/octocode-cli/src/cli/parser.ts
+++ b/packages/octocode-cli/src/cli/parser.ts
@@ -31,6 +31,8 @@ const OPTIONS_WITH_VALUES = new Set([
   'input',
   'responseCharLength',
   'responseCharOffset',
+  'file',
+  'timeout',
 ]);
 
 const BOOLEAN_OPTIONS = new Set([
@@ -77,6 +79,7 @@ const AGENT_SUBCOMMANDS = new Set([
   'search-repos',
   'search-prs',
   'package-search',
+  'exec',
 ]);
 
 function shouldConsumeNextValue(args: ParsedArgs, key: string): boolean {

--- a/packages/octocode-cli/src/cli/parser.ts
+++ b/packages/octocode-cli/src/cli/parser.ts
@@ -55,6 +55,13 @@ const BOOLEAN_OPTIONS = new Set([
   'list',
   'schema',
   'tools-context',
+  'full-content',
+  'merged',
+  'draft',
+  'with-comments',
+  'with-commits',
+  'npm-fetch-metadata',
+  'python-fetch-metadata',
 ]);
 
 const SINGLE_DASH_LONG_OPTIONS = new Set([
@@ -63,12 +70,25 @@ const SINGLE_DASH_LONG_OPTIONS = new Set([
   'responseCharOffset',
 ]);
 
+const AGENT_SUBCOMMANDS = new Set([
+  'search-code',
+  'get-file',
+  'view-structure',
+  'search-repos',
+  'search-prs',
+  'package-search',
+]);
+
 function shouldConsumeNextValue(args: ParsedArgs, key: string): boolean {
   if (BOOLEAN_OPTIONS.has(key)) {
     return false;
   }
 
   if (OPTIONS_WITH_VALUES.has(key)) {
+    return true;
+  }
+
+  if (args.command && AGENT_SUBCOMMANDS.has(args.command)) {
     return true;
   }
 

--- a/packages/octocode-cli/src/cli/tool-command.ts
+++ b/packages/octocode-cli/src/cli/tool-command.ts
@@ -33,15 +33,15 @@ import {
   PackageSearchQuerySchema,
 } from 'octocode-mcp/public';
 
-type ToolResult = {
+export type ToolResult = {
   content?: Array<{ type?: string; text?: string }>;
   structuredContent?: unknown;
   isError?: boolean;
 };
 
-type ToolExecutor = (input: unknown) => Promise<ToolResult>;
+export type ToolExecutor = (input: unknown) => Promise<ToolResult>;
 
-interface ToolDefinition {
+export interface ToolDefinition {
   name: string;
   schema: z.ZodType;
   execute: ToolExecutor;
@@ -86,7 +86,7 @@ function wrapExecutor<TInput>(
   return async (input: unknown) => fn(input as TInput);
 }
 
-const TOOL_DEFINITIONS: ToolDefinition[] = [
+export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'githubSearchCode',
     schema: GitHubCodeSearchQuerySchema,
@@ -263,7 +263,7 @@ function buildDefaultGoal(toolName: string): string {
   return `Execute ${toolName} via octocode-cli`;
 }
 
-function applyDefaultQueryFields(
+export function applyDefaultQueryFields(
   toolName: string,
   index: number,
   query: Record<string, unknown>
@@ -298,7 +298,7 @@ function applyDefaultQueryFields(
   return nextQuery;
 }
 
-function normalizeQueryObject(query: unknown): Record<string, unknown> {
+export function normalizeQueryObject(query: unknown): Record<string, unknown> {
   if (!isRecord(query)) {
     throw new Error('Tool input must be a JSON object or an array of objects.');
   }
@@ -695,7 +695,7 @@ function formatValidationIssues(error: z.ZodError): string[] {
   });
 }
 
-async function ensureToolRuntimeReady(): Promise<void> {
+export async function ensureToolRuntimeReady(): Promise<void> {
   if (!toolRuntimeInitPromise) {
     toolRuntimeInitPromise = (async () => {
       await initializeMcp();

--- a/packages/octocode-cli/src/index.ts
+++ b/packages/octocode-cli/src/index.ts
@@ -1,53 +1,6 @@
-import { c, bold, dim } from './utils/colors.js';
-import { clearScreen } from './utils/platform.js';
-import { loadInquirer } from './utils/prompts.js';
-import { printWelcome, printGoodbye } from './ui/header.js';
-import { Spinner } from './utils/spinner.js';
-import {
-  checkAndPrintEnvironmentWithLoader,
-  printNodeDoctorHint,
-  hasEnvironmentIssues,
-} from './ui/install/index.js';
-import { runMenuLoop } from './ui/menu.js';
+import { dim } from './utils/colors.js';
 import { runCLI } from './cli/index.js';
-
-function printEnvHeader(): void {
-  console.log(c('blue', '━'.repeat(66)));
-  console.log(`  🔍 ${bold('Environment')}`);
-  console.log(c('blue', '━'.repeat(66)));
-}
-
-async function runInteractiveMode(): Promise<void> {
-  const loadingSpinner = new Spinner('  Starting...').start();
-  await loadInquirer();
-  loadingSpinner.clear();
-
-  clearScreen();
-  printWelcome();
-
-  printEnvHeader();
-
-  const envStatus = await checkAndPrintEnvironmentWithLoader();
-
-  if (hasEnvironmentIssues(envStatus)) {
-    console.log();
-    console.log(
-      `  ${dim('💡')} ${dim('Run')} ${c('cyan', 'npx node-doctor')} ${dim('for diagnostics')}`
-    );
-  }
-
-  if (!envStatus.nodeInstalled) {
-    console.log();
-    console.log(
-      `  ${c('red', '✗')} ${bold('Node.js is required to run octocode-mcp')}`
-    );
-    printNodeDoctorHint();
-    printGoodbye();
-    return;
-  }
-
-  await runMenuLoop();
-}
+import { showHelp } from './cli/help.js';
 
 async function main(): Promise<void> {
   const handled = await runCLI();
@@ -56,7 +9,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  await runInteractiveMode();
+  showHelp();
 }
 
 function handleTermination(): void {

--- a/packages/octocode-cli/src/interactive.ts
+++ b/packages/octocode-cli/src/interactive.ts
@@ -1,0 +1,49 @@
+import { c, bold, dim } from './utils/colors.js';
+import { clearScreen } from './utils/platform.js';
+import { loadInquirer } from './utils/prompts.js';
+import { printWelcome, printGoodbye } from './ui/header.js';
+import { Spinner } from './utils/spinner.js';
+import {
+  checkAndPrintEnvironmentWithLoader,
+  printNodeDoctorHint,
+  hasEnvironmentIssues,
+} from './ui/install/index.js';
+import { runMenuLoop } from './ui/menu.js';
+
+function printEnvHeader(): void {
+  console.log(c('blue', '━'.repeat(66)));
+  console.log(`  🔍 ${bold('Environment')}`);
+  console.log(c('blue', '━'.repeat(66)));
+}
+
+export async function runInteractiveMode(): Promise<void> {
+  const loadingSpinner = new Spinner('  Starting...').start();
+  await loadInquirer();
+  loadingSpinner.clear();
+
+  clearScreen();
+  printWelcome();
+
+  printEnvHeader();
+
+  const envStatus = await checkAndPrintEnvironmentWithLoader();
+
+  if (hasEnvironmentIssues(envStatus)) {
+    console.log();
+    console.log(
+      `  ${dim('💡')} ${dim('Run')} ${c('cyan', 'npx node-doctor')} ${dim('for diagnostics')}`
+    );
+  }
+
+  if (!envStatus.nodeInstalled) {
+    console.log();
+    console.log(
+      `  ${c('red', '✗')} ${bold('Node.js is required to run octocode-mcp')}`
+    );
+    printNodeDoctorHint();
+    printGoodbye();
+    return;
+  }
+
+  await runMenuLoop();
+}

--- a/packages/octocode-cli/tests/cli/agent-commands.test.ts
+++ b/packages/octocode-cli/tests/cli/agent-commands.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const publicMocks = vi.hoisted(() => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  initializeProviders: vi.fn().mockResolvedValue([]),
+  loadToolContent: vi.fn().mockResolvedValue({
+    instructions: 'Use Octocode tools carefully.',
+    prompts: {},
+    toolNames: {},
+    baseSchema: {
+      mainResearchGoal: 'main goal',
+      researchGoal: 'goal',
+      reasoning: 'reasoning',
+      bulkQuery: (toolName: string) => `queries for ${toolName}`,
+    },
+    tools: {},
+    baseHints: { hasResults: [], empty: [] },
+    genericErrorHints: [],
+  }),
+  searchMultipleGitHubCode: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'github code output' }],
+  }),
+  fetchMultipleGitHubFileContents: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'file content' }],
+  }),
+  exploreMultipleRepositoryStructures: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'tree' }],
+  }),
+  searchMultipleGitHubRepos: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'repos' }],
+  }),
+  searchMultipleGitHubPullRequests: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'prs' }],
+  }),
+  searchPackages: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'pkg' }],
+  }),
+  noop: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'ok' }],
+  }),
+}));
+
+vi.mock('octocode-mcp/public', async () => {
+  const { z } = await import('zod/v4');
+
+  const localBase = z.object({
+    id: z.string(),
+    researchGoal: z.string(),
+    reasoning: z.string(),
+  });
+
+  const githubBase = z.object({
+    id: z.string(),
+    mainResearchGoal: z.string(),
+    researchGoal: z.string(),
+    reasoning: z.string(),
+  });
+
+  return {
+    initialize: publicMocks.initialize,
+    initializeProviders: publicMocks.initializeProviders,
+    loadToolContent: publicMocks.loadToolContent,
+    executeRipgrepSearch: publicMocks.noop,
+    executeFetchContent: publicMocks.noop,
+    executeFindFiles: publicMocks.noop,
+    executeViewStructure: publicMocks.noop,
+    executeGotoDefinition: publicMocks.noop,
+    executeFindReferences: publicMocks.noop,
+    executeCallHierarchy: publicMocks.noop,
+    fetchMultipleGitHubFileContents:
+      publicMocks.fetchMultipleGitHubFileContents,
+    searchMultipleGitHubCode: publicMocks.searchMultipleGitHubCode,
+    searchMultipleGitHubPullRequests:
+      publicMocks.searchMultipleGitHubPullRequests,
+    searchMultipleGitHubRepos: publicMocks.searchMultipleGitHubRepos,
+    exploreMultipleRepositoryStructures:
+      publicMocks.exploreMultipleRepositoryStructures,
+    searchPackages: publicMocks.searchPackages,
+    RipgrepQuerySchema: localBase.extend({
+      path: z.string(),
+      pattern: z.string(),
+    }),
+    FetchContentQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    FindFilesQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    ViewStructureQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPGotoDefinitionQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPFindReferencesQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPCallHierarchyQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    FileContentQuerySchema: githubBase.extend({
+      owner: z.string(),
+      repo: z.string(),
+      path: z.string(),
+      branch: z.string().optional(),
+      matchString: z.string().optional(),
+      matchContextLines: z.number().optional(),
+      startLine: z.number().optional(),
+      endLine: z.number().optional(),
+      fullContent: z.boolean().optional(),
+    }),
+    GitHubCodeSearchQuerySchema: githubBase.extend({
+      keywordsToSearch: z.array(z.string()),
+      owner: z.string().optional(),
+      repo: z.string().optional(),
+      path: z.string().optional(),
+      filename: z.string().optional(),
+      extension: z.string().optional(),
+      match: z.string().optional(),
+      limit: z.number().optional(),
+      page: z.number().optional(),
+    }),
+    GitHubPullRequestSearchQuerySchema: githubBase.extend({
+      query: z.string().optional(),
+      owner: z.string().optional(),
+      repo: z.string().optional(),
+      state: z.string().optional(),
+      author: z.string().optional(),
+      merged: z.boolean().optional(),
+      draft: z.boolean().optional(),
+      withComments: z.boolean().optional(),
+      withCommits: z.boolean().optional(),
+      limit: z.number().optional(),
+    }),
+    GitHubReposSearchSingleQuerySchema: githubBase.extend({
+      keywordsToSearch: z.array(z.string()).optional(),
+      topicsToSearch: z.array(z.string()).optional(),
+      owner: z.string().optional(),
+      stars: z.string().optional(),
+      sort: z.string().optional(),
+      limit: z.number().optional(),
+    }),
+    GitHubViewRepoStructureQuerySchema: githubBase.extend({
+      owner: z.string(),
+      repo: z.string(),
+      branch: z.string().optional(),
+      path: z.string().optional(),
+      depth: z.number().optional(),
+    }),
+    PackageSearchQuerySchema: githubBase.extend({
+      ecosystem: z.enum(['npm', 'python']),
+      name: z.string(),
+      searchLimit: z.number().optional(),
+      npmFetchMetadata: z.boolean().optional(),
+      pythonFetchMetadata: z.boolean().optional(),
+    }),
+  };
+});
+
+describe('agent subcommands', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: typeof process.exitCode;
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    process.exitCode = originalExitCode;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: originalIsTTY,
+    });
+  });
+
+  async function runAgent(
+    name: string,
+    options: Record<string, string | boolean>
+  ) {
+    const { agentCommands } = await import('../../src/cli/agent-commands.js');
+    const cmd = agentCommands.find(c => c.name === name);
+    if (!cmd) throw new Error(`agent subcommand not found: ${name}`);
+    await cmd.handler({ command: name, args: [], options });
+  }
+
+  it('search-code: maps --query to keywordsToSearch array and autofills goals', async () => {
+    await runAgent('search-code', {
+      query: 'useReducer, dispatch',
+      owner: 'facebook',
+      repo: 'react',
+      limit: '5',
+    });
+
+    expect(publicMocks.searchMultipleGitHubCode).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          keywordsToSearch: ['useReducer', 'dispatch'],
+          owner: 'facebook',
+          repo: 'react',
+          limit: 5,
+          mainResearchGoal: 'Execute githubSearchCode via octocode-cli',
+          researchGoal: 'Execute githubSearchCode via octocode-cli',
+          reasoning: 'Executed via octocode-cli tool command',
+        }),
+      ],
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('search-code: rejects non-numeric --limit with exit 1', async () => {
+    await runAgent('search-code', {
+      query: 'foo',
+      limit: 'abc',
+    });
+
+    expect(publicMocks.searchMultipleGitHubCode).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('get-file: fails with exit 1 when required flags missing', async () => {
+    await runAgent('get-file', { owner: 'facebook' });
+
+    expect(publicMocks.fetchMultipleGitHubFileContents).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('get-file: passes full-content boolean and matchString kebab→camel', async () => {
+    await runAgent('get-file', {
+      owner: 'facebook',
+      repo: 'react',
+      path: 'packages/react/src/React.js',
+      'match-string': 'useState',
+      'full-content': true,
+    });
+
+    expect(publicMocks.fetchMultipleGitHubFileContents).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          owner: 'facebook',
+          repo: 'react',
+          path: 'packages/react/src/React.js',
+          matchString: 'useState',
+          fullContent: true,
+        }),
+      ],
+    });
+  });
+
+  it('view-structure: passes numeric depth and branch', async () => {
+    await runAgent('view-structure', {
+      owner: 'bgauryy',
+      repo: 'octocode-mcp',
+      branch: 'main',
+      depth: '2',
+    });
+
+    expect(
+      publicMocks.exploreMultipleRepositoryStructures
+    ).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          owner: 'bgauryy',
+          repo: 'octocode-mcp',
+          branch: 'main',
+          depth: 2,
+        }),
+      ],
+    });
+  });
+
+  it('search-repos: splits comma-separated topics into array', async () => {
+    await runAgent('search-repos', {
+      topics: 'typescript, mcp',
+      stars: '>=100',
+    });
+
+    expect(publicMocks.searchMultipleGitHubRepos).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          topicsToSearch: ['typescript', 'mcp'],
+          stars: '>=100',
+        }),
+      ],
+    });
+  });
+
+  it('search-prs: passes merged/draft booleans and owner', async () => {
+    await runAgent('search-prs', {
+      owner: 'facebook',
+      repo: 'react',
+      merged: true,
+      draft: true,
+    });
+
+    expect(publicMocks.searchMultipleGitHubPullRequests).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          owner: 'facebook',
+          repo: 'react',
+          merged: true,
+          draft: true,
+        }),
+      ],
+    });
+  });
+
+  it('package-search: passes ecosystem and name and npm-fetch-metadata boolean', async () => {
+    await runAgent('package-search', {
+      name: 'react',
+      ecosystem: 'npm',
+      'npm-fetch-metadata': true,
+    });
+
+    expect(publicMocks.searchPackages).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          name: 'react',
+          ecosystem: 'npm',
+          npmFetchMetadata: true,
+        }),
+      ],
+    });
+  });
+
+  it('package-search: exit 1 on missing required --name', async () => {
+    await runAgent('package-search', { ecosystem: 'npm' });
+
+    expect(publicMocks.searchPackages).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('--json: prints JSON envelope to stdout', async () => {
+    await runAgent('search-code', {
+      query: 'foo',
+      json: true,
+    });
+
+    expect(publicMocks.searchMultipleGitHubCode).toHaveBeenCalledTimes(1);
+    const printedJsonCall = consoleLogSpy.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' && (call[0] as string).startsWith('{')
+    );
+    expect(printedJsonCall).toBeDefined();
+    expect(printedJsonCall?.[0]).toContain('"content"');
+  });
+
+  it('sets exit code 1 when tool result reports isError', async () => {
+    publicMocks.searchMultipleGitHubCode.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'oops' }],
+      isError: true,
+    });
+
+    await runAgent('search-code', { query: 'foo' });
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/octocode-cli/tests/cli/exec-command.test.ts
+++ b/packages/octocode-cli/tests/cli/exec-command.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const publicMocks = vi.hoisted(() => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  initializeProviders: vi.fn().mockResolvedValue([]),
+  loadToolContent: vi.fn().mockResolvedValue({
+    instructions: '',
+    prompts: {},
+    toolNames: {},
+    baseSchema: {},
+    tools: {},
+    baseHints: { hasResults: [], empty: [] },
+    genericErrorHints: [],
+  }),
+  searchMultipleGitHubCode: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'github code output' }],
+  }),
+  fetchMultipleGitHubFileContents: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'file content' }],
+  }),
+  exploreMultipleRepositoryStructures: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'tree' }],
+  }),
+  searchMultipleGitHubRepos: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'repos' }],
+  }),
+  searchMultipleGitHubPullRequests: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'prs' }],
+  }),
+  searchPackages: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'pkg' }],
+  }),
+  noop: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'ok' }],
+  }),
+}));
+
+vi.mock('octocode-mcp/public', async () => {
+  const { z } = await import('zod/v4');
+
+  const localBase = z.object({
+    id: z.string(),
+    researchGoal: z.string(),
+    reasoning: z.string(),
+  });
+
+  const githubBase = z.object({
+    id: z.string(),
+    mainResearchGoal: z.string(),
+    researchGoal: z.string(),
+    reasoning: z.string(),
+  });
+
+  return {
+    initialize: publicMocks.initialize,
+    initializeProviders: publicMocks.initializeProviders,
+    loadToolContent: publicMocks.loadToolContent,
+    executeRipgrepSearch: publicMocks.noop,
+    executeFetchContent: publicMocks.noop,
+    executeFindFiles: publicMocks.noop,
+    executeViewStructure: publicMocks.noop,
+    executeGotoDefinition: publicMocks.noop,
+    executeFindReferences: publicMocks.noop,
+    executeCallHierarchy: publicMocks.noop,
+    fetchMultipleGitHubFileContents:
+      publicMocks.fetchMultipleGitHubFileContents,
+    searchMultipleGitHubCode: publicMocks.searchMultipleGitHubCode,
+    searchMultipleGitHubPullRequests:
+      publicMocks.searchMultipleGitHubPullRequests,
+    searchMultipleGitHubRepos: publicMocks.searchMultipleGitHubRepos,
+    exploreMultipleRepositoryStructures:
+      publicMocks.exploreMultipleRepositoryStructures,
+    searchPackages: publicMocks.searchPackages,
+    RipgrepQuerySchema: localBase.extend({
+      path: z.string(),
+      pattern: z.string(),
+    }),
+    FetchContentQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    FindFilesQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    ViewStructureQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPGotoDefinitionQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPFindReferencesQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    LSPCallHierarchyQuerySchema: localBase.extend({
+      path: z.string(),
+    }),
+    FileContentQuerySchema: githubBase.extend({
+      owner: z.string(),
+      repo: z.string(),
+      path: z.string(),
+    }),
+    GitHubCodeSearchQuerySchema: githubBase.extend({
+      keywordsToSearch: z.array(z.string()),
+      owner: z.string().optional(),
+      repo: z.string().optional(),
+    }),
+    GitHubPullRequestSearchQuerySchema: githubBase.extend({
+      owner: z.string().optional(),
+      repo: z.string().optional(),
+    }),
+    GitHubReposSearchSingleQuerySchema: githubBase.extend({
+      keywordsToSearch: z.array(z.string()).optional(),
+    }),
+    GitHubViewRepoStructureQuerySchema: githubBase.extend({
+      owner: z.string(),
+      repo: z.string(),
+    }),
+    PackageSearchQuerySchema: githubBase.extend({
+      ecosystem: z.enum(['npm', 'python']),
+      name: z.string(),
+    }),
+  };
+});
+
+describe('exec command / oct namespace', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: typeof process.exitCode;
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    process.exitCode = originalExitCode;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: originalIsTTY,
+    });
+  });
+
+  async function runExec(
+    options: Record<string, string | boolean>,
+    positional: string[] = []
+  ) {
+    const { execCommand } = await import('../../src/cli/exec-command.js');
+    await execCommand.handler({ command: 'exec', args: positional, options });
+  }
+
+  it('runs an inline script that calls oct.searchCode', async () => {
+    await runExec({}, [
+      'const r = await oct.searchCode({ owner: "facebook", repo: "react", keywordsToSearch: ["useState"] }); return r.content[0].text;',
+    ]);
+
+    expect(publicMocks.searchMultipleGitHubCode).toHaveBeenCalledTimes(1);
+    expect(publicMocks.searchMultipleGitHubCode).toHaveBeenCalledWith({
+      queries: [
+        expect.objectContaining({
+          owner: 'facebook',
+          repo: 'react',
+          keywordsToSearch: ['useState'],
+          mainResearchGoal: 'Execute githubSearchCode via octocode-cli',
+          researchGoal: 'Execute githubSearchCode via octocode-cli',
+          reasoning: 'Executed via octocode-cli tool command',
+        }),
+      ],
+    });
+
+    const printedReturn = consoleLogSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === 'github code output'
+    );
+    expect(printedReturn).toBeDefined();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('captures console.log output from user scripts', async () => {
+    await runExec({}, ['console.log("hello", "world"); return "done";']);
+
+    const printed = consoleLogSpy.mock.calls.map((call: unknown[]) => call[0]);
+    expect(printed).toContain('hello world');
+    expect(printed).toContain('done');
+  });
+
+  it('--json prints { returnValue, logs }', async () => {
+    await runExec({ json: true }, [
+      'console.log("hi"); return { answer: 42 };',
+    ]);
+
+    const jsonCall = consoleLogSpy.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"returnValue"')
+    );
+    expect(jsonCall).toBeDefined();
+    const parsed = JSON.parse(jsonCall?.[0] as string);
+    expect(parsed.returnValue).toEqual({ answer: 42 });
+    expect(parsed.logs).toEqual(['hi']);
+  });
+
+  it('runs Promise.all across multiple oct calls', async () => {
+    await runExec({}, [
+      'const results = await Promise.all([' +
+        'oct.searchCode({ owner: "a", repo: "b", keywordsToSearch: ["x"] }),' +
+        'oct.getFile({ owner: "a", repo: "b", path: "README.md" }),' +
+        ']); return results.length;',
+    ]);
+
+    expect(publicMocks.searchMultipleGitHubCode).toHaveBeenCalledTimes(1);
+    expect(publicMocks.fetchMultipleGitHubFileContents).toHaveBeenCalledTimes(
+      1
+    );
+    const printed = consoleLogSpy.mock.calls.map((call: unknown[]) => call[0]);
+    expect(printed).toContain('2');
+  });
+
+  it('blocks access to require inside the sandbox', async () => {
+    await runExec({}, ['return typeof require;']);
+
+    const printed = consoleLogSpy.mock.calls.map((call: unknown[]) => call[0]);
+    expect(printed).toContain('undefined');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('blocks access to process inside the sandbox', async () => {
+    await runExec({}, ['return typeof process;']);
+
+    const printed = consoleLogSpy.mock.calls.map((call: unknown[]) => call[0]);
+    expect(printed).toContain('undefined');
+  });
+
+  it('exits with code 1 on script syntax error', async () => {
+    await runExec({}, ['const x = ;']);
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('exits with code 1 on runtime error thrown by user script', async () => {
+    await runExec({}, ['throw new Error("boom");']);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits with code 1 and surfaces zod validation error from oct.*', async () => {
+    await runExec({}, [
+      'await oct.searchCode({ owner: "x", repo: "y" });', // missing keywordsToSearch
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(publicMocks.searchMultipleGitHubCode).not.toHaveBeenCalled();
+  });
+
+  it('--timeout enforces a deadline', async () => {
+    await runExec({ timeout: '50' }, [
+      'await new Promise(r => setTimeout(r, 500)); return "late";',
+    ]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reads script from --file', async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'octocode-exec-'));
+    try {
+      const scriptPath = path.join(tmp, 'script.js');
+      writeFileSync(scriptPath, 'return await oct.tools();', 'utf8');
+      await runExec({ file: scriptPath });
+
+      const printed = consoleLogSpy.mock.calls.map(
+        (call: unknown[]) => call[0]
+      );
+      const joined = printed.join('\n');
+      expect(joined).toContain('githubSearchCode');
+      expect(joined).toContain('packageSearch');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('exits with code 1 when no script is provided', async () => {
+    await runExec({}, []);
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('exits with code 1 when --file points at a missing file', async () => {
+    await runExec({ file: '/definitely/does/not/exist.js' });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits with code 1 on invalid --timeout value', async () => {
+    await runExec({ timeout: 'abc' }, ['return 1;']);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('oct.tool(name, input) routes to the right executor', async () => {
+    await runExec({}, [
+      'const r = await oct.tool("packageSearch", { name: "react", ecosystem: "npm" }); return r.content[0].text;',
+    ]);
+
+    expect(publicMocks.searchPackages).toHaveBeenCalledWith({
+      queries: [expect.objectContaining({ name: 'react', ecosystem: 'npm' })],
+    });
+  });
+});

--- a/skills/octocode-cli/SKILL.md
+++ b/skills/octocode-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: octocode-cli
-description: Use `octocode-cli` subcommands to execute Octocode MCP tools from a terminal without wiring MCP. Use when the user asks to "run octocode from shell", "use octocode without MCP", "call githubSearchCode from CLI", or wants a one-off GitHub code/file/PR search in the terminal.
+description: Use `octocode-cli` subcommands (or `exec` code mode) to execute Octocode MCP tools from a terminal without wiring MCP. Use when the user asks to "run octocode from shell", "use octocode without MCP", "call githubSearchCode from CLI", wants a one-off GitHub code/file/PR search, or needs to orchestrate multiple tool calls in one command via a JS script.
 ---
 
 # Octocode CLI — Agent Cheat Sheet
 
-Six flag-driven subcommands. One tool per subcommand. No MCP server required.
+Six flag-driven subcommands plus `exec` (code mode). No MCP server required.
 
 | Subcommand | Tool | Required flags |
 |---|---|---|
@@ -15,6 +15,7 @@ Six flag-driven subcommands. One tool per subcommand. No MCP server required.
 | `search-repos` | `githubSearchRepositories` | _(none)_ |
 | `search-prs` | `githubSearchPullRequests` | _(none)_ |
 | `package-search` | `packageSearch` | `--name --ecosystem` |
+| `exec` | code mode (`oct.*` namespace) | positional script, `--file`, or stdin |
 
 Auto-filled: `id`, `mainResearchGoal`, `researchGoal`, `reasoning`. Don't pass them.
 
@@ -40,6 +41,36 @@ octocode-cli search-prs --owner facebook --repo react --merged --limit 20
 # Package search
 octocode-cli package-search --name react --ecosystem npm --npm-fetch-metadata
 ```
+
+## Code mode (`exec`)
+
+Use `exec` when one request needs multiple tool calls. The script runs inside a sandbox with a typed `oct.*` namespace — no `require`, `process`, or network access. `await` and `return` work at the top level.
+
+```bash
+# Parallel code search across repos
+octocode-cli exec '
+  const repos = [["facebook","react"], ["vuejs","core"]];
+  const hits = await Promise.all(
+    repos.map(([owner, repo]) =>
+      oct.searchCode({ owner, repo, keywordsToSearch: ["useState"] })
+    )
+  );
+  return hits.map(r => r.content?.[0]?.text?.length ?? 0);
+'
+
+# Script from file
+octocode-cli exec --file ./research.js
+
+# Via stdin
+echo 'return await oct.tools()' | octocode-cli exec
+
+# JSON output (returnValue + captured logs)
+octocode-cli exec --json 'console.log("hi"); return { ok: true }'
+```
+
+`oct.*` surface: `searchCode`, `getFile`, `viewStructure`, `searchRepos`, `searchPullRequests`, `packageSearch`, `localSearchCode`, `localGetFile`, `localFindFiles`, `localViewStructure`, `lspGotoDefinition`, `lspFindReferences`, `lspCallHierarchy`. Generic entrypoints: `oct.tool(name, input)` and `oct.tools()`.
+
+Each function accepts a single query object, an array of queries, or `{ queries: [...] }`. Shared research fields are auto-filled. Timeout is `--timeout <ms>` (default 60000).
 
 ## Flag conventions
 

--- a/skills/octocode-cli/SKILL.md
+++ b/skills/octocode-cli/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: octocode-cli
+description: Use `octocode-cli` subcommands to execute Octocode MCP tools from a terminal without wiring MCP. Use when the user asks to "run octocode from shell", "use octocode without MCP", "call githubSearchCode from CLI", or wants a one-off GitHub code/file/PR search in the terminal.
+---
+
+# Octocode CLI — Agent Cheat Sheet
+
+Six flag-driven subcommands. One tool per subcommand. No MCP server required.
+
+| Subcommand | Tool | Required flags |
+|---|---|---|
+| `search-code` | `githubSearchCode` | `--query` |
+| `get-file` | `githubGetFileContent` | `--owner --repo --path` |
+| `view-structure` | `githubViewRepoStructure` | `--owner --repo` |
+| `search-repos` | `githubSearchRepositories` | _(none)_ |
+| `search-prs` | `githubSearchPullRequests` | _(none)_ |
+| `package-search` | `packageSearch` | `--name --ecosystem` |
+
+Auto-filled: `id`, `mainResearchGoal`, `researchGoal`, `reasoning`. Don't pass them.
+
+## Quick recipes
+
+```bash
+# Code search
+octocode-cli search-code --query 'useReducer,dispatch' --owner facebook --repo react --limit 5
+
+# Fetch a file around a match
+octocode-cli get-file --owner facebook --repo react \
+  --path packages/react/src/React.js --match-string useState
+
+# Tree view
+octocode-cli view-structure --owner bgauryy --repo octocode-mcp --depth 2
+
+# Repo search by topics/stars
+octocode-cli search-repos --topics typescript,mcp --stars '>=100' --sort stars
+
+# Merged PR search
+octocode-cli search-prs --owner facebook --repo react --merged --limit 20
+
+# Package search
+octocode-cli package-search --name react --ecosystem npm --npm-fetch-metadata
+```
+
+## Flag conventions
+
+- Comma-separated lists: `--query 'a,b,c'` → `keywordsToSearch: ['a','b','c']`.
+- Kebab-case flags map to camelCase fields: `--match-string` → `matchString`, `--full-content` → `fullContent`.
+- Numeric flags (`--limit`, `--depth`, `--start-line`, `--end-line`) are parsed as numbers. Non-numeric values exit with code 1.
+- Boolean flags: `--merged`, `--draft`, `--full-content`, `--with-comments`, `--with-commits`, `--npm-fetch-metadata`, `--python-fetch-metadata`.
+
+## Bulk queries via stdin
+
+Pipe `{"queries":[...]}` JSON to any subcommand. When stdin is present, command-line flags are ignored.
+
+```bash
+echo '{"queries":[
+  {"keywordsToSearch":["useState"],"owner":"facebook","repo":"react"},
+  {"keywordsToSearch":["useEffect"],"owner":"facebook","repo":"react"}
+]}' | octocode-cli search-code
+```
+
+## Output modes
+
+- Default: human-readable text (the tool's text content blocks).
+- `--json`: raw tool envelope, including `content` and `structuredContent`. Pipe into `jq` when parsing.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Tool ran and returned a non-error result |
+| `1` | Missing required flag, bad JSON on stdin, validation failure, or tool returned `isError: true` |
+
+## When to use which
+
+- **Finding code**: `search-code` with `--query` and optional `--owner/--repo/--path/--extension`.
+- **Reading a file**: `get-file`. Use `--match-string` + `--match-context-lines` for a window, `--start-line/--end-line` for a range, or `--full-content` for the whole file.
+- **Mapping a repo**: `view-structure`. `--depth 1` for a shallow tree, more for deeper.
+- **Discovering repos**: `search-repos` with `--topics` or `--query`, filter by `--stars`/`--sort`.
+- **PR archaeology**: `search-prs` with `--author`, `--merged`, date ranges.
+- **Package info**: `package-search` with `--ecosystem`. Add `--npm-fetch-metadata` or `--python-fetch-metadata` for registry details.
+
+## Authentication
+
+GitHub tools need a token. The CLI uses Octocode-stored creds or `gh` CLI, in that order. If neither is set:
+
+```bash
+octocode-cli login          # Octocode-managed OAuth
+# or
+gh auth login               # gh CLI token (also picked up)
+```


### PR DESCRIPTION
## Summary

Adds `octocode-cli exec` — a code-mode entrypoint that runs a small JS program against a typed `oct.*` namespace inside a Node `vm` sandbox. Lets agents compose multiple tool calls (`Promise.all`, loops, filtering, aggregation) in one CLI invocation instead of chaining many subcommand runs.

**Stacked on #387** — please review/merge that first. Diff here is additive on top of the agent-cli-p1 subcommands work.

## What's new

- `octocode-cli exec '<script>'` — inline script
- `octocode-cli exec --file ./research.js` — script from file
- `echo '...' | octocode-cli exec` — script from stdin
- `--timeout <ms>` (default 60000), `--json` for `{ returnValue, logs }`

## `oct.*` surface

13 tool functions (`oct.searchCode`, `oct.getFile`, `oct.viewStructure`, `oct.searchRepos`, `oct.searchPullRequests`, `oct.packageSearch`, `oct.localSearchCode`, `oct.localGetFile`, `oct.localFindFiles`, `oct.localViewStructure`, `oct.lspGotoDefinition`, `oct.lspFindReferences`, `oct.lspCallHierarchy`) plus generic `oct.tool(name, input)` and `oct.tools()`.

Input can be a single query object, an array of queries, or `{ queries: [...] }`. Shared research fields (`id`, `mainResearchGoal`, `researchGoal`, `reasoning`) are auto-filled. All inputs validated through the real tool Zod schemas.

## Sandbox

Default-deny: no `require`, `import`, `process`, `fs`, network access. Allowed globals: `JSON`, `Math`, `Date`, `Promise`, collections, `URL`, `Buffer`, `AbortController`, `setTimeout`/`clearTimeout`, and string/number helpers. Script body runs inside an async IIFE — `await` and `return` work at the top level. Timeout enforced via `Promise.race` (covers async work, which `vm.runInContext({timeout})` does not).

## Implementation notes

- Reuses `tool-command.ts` internals (`TOOL_DEFINITIONS`, `applyDefaultQueryFields`, `normalizeQueryObject`, `ensureToolRuntimeReady`) — promoted them to exports rather than duplicating.
- `captured console.*` output printed before the return value; `--json` swaps both into a structured envelope.
- Exit 1 on syntax error, runtime error, timeout, missing file, or Zod validation failure.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn lint` clean
- [x] `yarn vitest run` — 755 passed, including 15 new exec-command tests
- [x] `yarn build` clean
- [x] Smoke-tested live: `oct.packageSearch({name:"react",ecosystem:"npm"})` returned real npm registry results
- [x] Sandbox isolation verified: `typeof require`, `typeof process`, `typeof fs` all `"undefined"` from user script
- [x] All error paths set exit code 1: syntax error, timeout, missing file, invalid `--timeout`, no script, Zod validation