### PR TITLE
docs: use `octocode-cli install` as recommended entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 ### Recommended: Octocode CLI
 
 ```bash
-npx octocode-cli
+npx octocode-cli install
 ```
 
-Interactive setup wizard with GitHub OAuth, MCP server installation, and skills marketplace.
+Interactive setup wizard with GitHub OAuth, MCP server installation, and skills marketplace. Pass `--ide <ide>` for non-interactive install (e.g. `npx octocode-cli install --ide cursor`).
 
 ### Alternative Methods
 


### PR DESCRIPTION
## Summary
- Bare `npx octocode-cli` now prints help in the published CLI; `install` (aliased as `setup`) is the actual interactive entrypoint
- Update README's Recommended block to `npx octocode-cli install` and mention `--ide <ide>` for non-interactive installs

## Test plan
- [ ] `npx octocode-cli install` opens the interactive wizard
- [ ] `npx octocode-cli install --ide cursor` performs a non-interactive install